### PR TITLE
Faster, more Pythonic install w/o directly using "subprocess"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-setuptools
-six
-numpy
-scipy
-vispy

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,21 @@
 #!/usr/bin/env python
-from setuptools import setup
-import subprocess
-
+req = ['setuptools','six','numpy','scipy','vispy','pyqt']
+pipreq = ['watchdog','pyfftw','python-xlib'] 
+#
+import pip
 try:
-    subprocess.call(['conda','install','--file','requirements.txt'])
+    import conda.cli
+    conda.cli.main('install',*req)
 except Exception as e:
-    pass
+    req = req[:-1] + ['pyqt5']  # drop pyqt for pyqt5
+    pip.main(['install'] + req)
+pip.main(['install'] + pipreq)
+# %%
+from setuptools import setup
 
 setup(name='audio_visualizer_screenlet',
+      packages=['avs'],
+      author='Okko Hartikainen',
+      url='https://github.com/ninlith/audio-visualizer-screenlet',
 	  description='Cross-platform audio visualization desktop widget',
-      install_requires=['watchdog','pyfftw','python-xlib','pyqt5'],
-      packages=['avs']
 	  )


### PR DESCRIPTION
`setup.py` is more Pythonic, faster, and better for general cross-platform installs:
* setup.py does not directly use subprocess
* attempts to use `conda` prereq manager
* where `conda` not available, fall back to `pip`, and use .whl instead of source when available (faster install).
