### PR TITLE
fix for issue #5 - segfaults on Debian 9

### DIFF
--- a/avs/input/pulseaudio.py
+++ b/avs/input/pulseaudio.py
@@ -112,6 +112,10 @@ class Pulserecorder(object):
         ba.minreq    = -1
         ba.fragsize  = -1
 
+        class struct_pa_simple(ctypes.Structure):
+            pass
+        pa.pa_simple_new.restype = ctypes.POINTER(struct_pa_simple)
+
         stream = pa.pa_simple_new(
             None,                # Server name, or NULL for default.
             self.name,           # Client name.


### PR DESCRIPTION
Added return type definition for pa_simple_new() fixes segfault.